### PR TITLE
Fix PlantUML link for context diagram and container diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ This repository is a "central landing zone" to document and share the architectu
 
 The [context diagram](https://c4model.com/#SystemContextDiagram) shows the highest level of the Social Care system. It depicts the key users and systems.
 
-![System Context Diagram](https://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/LBHackney-IT/social-care-architecture/test-plantuml/images/system-context.iuml)
+![System Context Diagram](https://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/LBHackney-IT/social-care-architecture/main/images/system-context.iuml)
 
 ## Container Diagram
 
 The [container diagram](https://c4model.com/#ContainerDiagram) shows the interacting systems within the Social Care system.
 
-![System container Diagram](https://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/LBHackney-IT/social-care-architecture/test-plantuml/images/system-container.iuml)
+![System container Diagram](https://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/LBHackney-IT/social-care-architecture/main/images/system-container.iuml)
 
 
 ## Architecture Decision Records


### PR DESCRIPTION
This specified `test-plantuml` which is a branch that only existed
for the PR which meant the `src` we were provided doesn't exist
anymore.

Since we are mainly concerned with it working on `main`, it's just been
updated to hardcode that in. However, this does mean it won't work
for other branches.