### PR TITLE
Update descriptions to align with service API container diagram

### DIFF
--- a/images/system-container.iuml
+++ b/images/system-container.iuml
@@ -25,9 +25,9 @@ System_Boundary(googles, "Google") {
 System_Boundary(system, "Social Care") {
 
   Container(social_care_front_end, "Social Care Front End", "Lambda, Next.js (React)", "Allows practitioners to edit case information.")
-  Container(social_care_service_api, "Social Care Case Viewer Service API", "Lambda, C#", "To be DESCRIBED")
-  Container(mosaic_platform_api, "Mosaic Platform Api", "Lambda, C#", "Provides person search")
-  Container(mosaic_historic_data_api, "Residents Social Care Platform API",  "Lambda, C#", "Serves historic read-only case and visit data")
+  Container(social_care_service_api, "Social Care Case Viewer Service API", "Lambda, C#", "Provides backend API for the Social Care Front End")
+  Container(mosaic_platform_api, "Mosaic Resident Information Platform API", "Lambda, C#", "Provides person search")
+  Container(mosaic_historic_data_api, "Residents Social Care Platform API",  "Lambda, C#", "Provides historic case and visit data")
 }
 
 Rel(care_practitioners, social_care_front_end, "Manage cases using", "JSON/HTTPS")

--- a/images/system-container.iuml
+++ b/images/system-container.iuml
@@ -6,8 +6,6 @@
 !include <office/Users/mobile_user.puml>
 !include https://raw.githubusercontent.com/LBHackney-IT/cv-19-res-support-v3/development/docs/diagrams/c4_shared.puml
 
-LAYOUT_AS_SKETCH()
-
 title Social Care System Container Diagram
 
 Person(care_practitioners, Social Care Practitioner, "<$user> <$user>\n Adult and Children" )


### PR DESCRIPTION
In https://github.com/LBHackney-IT/social-care-case-viewer-api/pull/193, we added a container diagram for the Social Care Case Viewer API and in that we had updated the descriptions of containers.