### PR TITLE
Add Links to Hackney ADR repository

### DIFF
--- a/docs/decisions/index.md
+++ b/docs/decisions/index.md
@@ -19,7 +19,7 @@ The records in this site:
 
 ## Tools
 
-Architecture decision records [ADR] are generated and maintained using Nat Pryce's [adr-tools](https://github.com/npryce/adr-tools). As each ADR is plain text, they may be added without the tools - however the tools do help maintain consistency.
+ADRs are generated and maintained using Nat Pryce's [adr-tools](https://github.com/npryce/adr-tools). As each ADR is plain text, they may be added without the tools - however the tools do help maintain consistency.
 
 ## Records
 

--- a/docs/decisions/index.md
+++ b/docs/decisions/index.md
@@ -11,6 +11,16 @@ architectural decision made along with its context and consequences. Further
 information can be found on Michael Nygard's
 [blog](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions).
 
+The records in this site:
+
+- Should be read in conjunction, and linked, with the [central Hackney IT ADR repository](https://github.com/LBHackney-IT/lbh-adrs).
+- The records defined here should document Social Care Tools __specific variations__ from the [Hackney IT ADR decisions](https://github.com/LBHackney-IT/lbh-adrs).
+- Please ensure the Hackney Repository contains links to this repository.
+
+## Tools
+
+Architecture decision records [ADR] are generated and maintained using Nat Pryce's [adr-tools](https://github.com/npryce/adr-tools). As each ADR is plain text, they may be added without the tools - however the tools do help maintain consistency.
+
 ## Records
 
 - [1. Record architecture decisions](/decisions/record-architecture-decisions)

--- a/docs/process.md
+++ b/docs/process.md
@@ -15,7 +15,6 @@ The process of documenting the architecture is intended be:
 - [C4 model](https://c4model.com/) architecture diagrams.
   - Context and container diagrams (levels 1 and 2), will be defined and stored in this repository.
   - Component diagrams (level 3), will be stored in the repository alongside the code.
-- [Architecture decision records](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions) will be used to document key decisions.
 
 ## Getting Started
 
@@ -25,7 +24,3 @@ The process of documenting the architecture is intended be:
 - Local editing is supported with Visual Studio Code and the [PlantUML](https://marketplace.visualstudio.com/items?itemName=jebbs.plantuml) extension.
   - Extension settings are defined in `.vscode/settings.json`
 - Live editing can also be done by using the [PlantUML Live Server](http://www.plantuml.com/plantuml/uml/)
-
-### Architecture Decision Records
-
-Architecture decision records [ADR] are generated and maintained using Nat Pryce's [adr-tools](https://github.com/npryce/adr-tools). As each ADR is plain text, they may be added without the tools - however the tools do help maintain consistency.


### PR DESCRIPTION
As title.

See also [PR](https://github.com/LBHackney-IT/lbh-adrs/pull/5) from [LBH-ADRS](https://github.com/LBHackney-IT/lbh-adrs) to back link to ADRS in this repository.