### PR TITLE
Add MASH referral form ingestion repo to related repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,12 +89,12 @@ Actions](https://github.com/features/actions) when `main` is updated, see
 
 | Name | Purpose |
 |-|-|
-| [MASH Social Care Referral Form Ingestion Script](https://github.com/LBHackney-IT/social-care-referral-form-ingestion) | Apps Script code that retrieves MASH form data submitted to Google Sheets, processes it and sends the data into Social Care System |
 | [LBH Social Care Frontend](https://github.com/LBHackney-IT/lbh-social-care-frontend) | Provides the UI/UX of the Social Care System. |
 | [Social Care Case Viewer API](https://github.com/LBHackney-IT/social-care-case-viewer-api) | Provides [service API](http://playbook.hackney.gov.uk/API-Playbook/platform_api_vs_service_api#a-service-apis) capabilities to the Social Care System. |
 | [Residents Social Care Platform API](https://github.com/LBHackney-IT/residents-social-care-platform-api) | Provides [platform API](http://playbook.hackney.gov.uk/API-Playbook/platform_api_vs_service_api#b-platform-apis) capabilities by providing historic social care data from Mosaic to the Social Care System. |
 | [Adult Social Care Care Package Builder Frontend](https://github.com/LBHackney-IT/lbh-adult-social-care-frontend) | Provides the UI/UX of the Adult Social Care Package System. |
 | [Adult Social Care Care Package Builder API](https://github.com/LBHackney-IT/lbh-adult-social-care-api) | Provides [service API](http://playbook.hackney.gov.uk/API-Playbook/platform_api_vs_service_api#a-service-apis) capabilities to the Adult Social Care Package System, allowing users to build and manage care packages. |
 | [Adult Social Care Package Builder Transactions API](https://github.com/LBHackney-IT/lbh-adult-social-care-transactions-api) | Provides [service API](http://playbook.hackney.gov.uk/API-Playbook/platform_api_vs_service_api#a-service-apis) transaction capabilities to the Adult Social Care Package System, managing package transactions, pay runs, invoices, bills etc. |
+| [MASH Social Care Referral Form Ingestion Script](https://github.com/LBHackney-IT/social-care-referral-form-ingestion) | Apps Script code that retrieves MASH form data submitted to Google Sheets, processes it and sends the data into Social Care System |
 | [Infrastructure](https://github.com/LBHackney-IT/infrastructure) | Provides a single place for AWS infrastructure defined using [Terraform](https://www.terraform.io) as [infrastructure as code](https://en.wikipedia.org/wiki/Infrastructure_as_code) as part of Hackney's new AWS account strategy. NB: Due to its recent introduction, the Social Care System has infrastructure across multiple places. |
 | [API Playbook](http://playbook.hackney.gov.uk/API-Playbook/) | Provides guidance to the standards of APIs within Hackney. |

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Actions](https://github.com/features/actions) when `main` is updated, see
 
 | Name | Purpose |
 |-|-|
+| [MASH Social Care Referral Form Ingestion Script](https://github.com/LBHackney-IT/social-care-referral-form-ingestion) | Apps Script code that retrieves MASH form data submitted to Google Sheets, processes it and sends the data into Social Care System |
 | [LBH Social Care Frontend](https://github.com/LBHackney-IT/lbh-social-care-frontend) | Provides the UI/UX of the Social Care System. |
 | [Social Care Case Viewer API](https://github.com/LBHackney-IT/social-care-case-viewer-api) | Provides [service API](http://playbook.hackney.gov.uk/API-Playbook/platform_api_vs_service_api#a-service-apis) capabilities to the Social Care System. |
 | [Residents Social Care Platform API](https://github.com/LBHackney-IT/residents-social-care-platform-api) | Provides [platform API](http://playbook.hackney.gov.uk/API-Playbook/platform_api_vs_service_api#b-platform-apis) capabilities by providing historic social care data from Mosaic to the Social Care System. |

--- a/docs/related-repositories.md
+++ b/docs/related-repositories.md
@@ -7,6 +7,7 @@ title: Related repositories
 
 | Name | Purpose |
 |-|-|
+| [MASH Social Care Referral Form Ingestion Script](https://github.com/LBHackney-IT/social-care-referral-form-ingestion) | Apps Script code that retrieves MASH form data submitted to Google Sheets, processes it and sends the data into Social Care System |
 | [LBH Social Care Frontend](https://github.com/LBHackney-IT/lbh-social-care-frontend) | Provides the UI/UX of the Social Care System. |
 | [Social Care Case Viewer API](https://github.com/LBHackney-IT/social-care-case-viewer-api) | Provides [service API](http://playbook.hackney.gov.uk/API-Playbook/platform_api_vs_service_api#a-service-apis) capabilities to the Social Care System. |
 | [Residents Social Care Platform API](https://github.com/LBHackney-IT/residents-social-care-platform-api) | Provides [platform API](http://playbook.hackney.gov.uk/API-Playbook/platform_api_vs_service_api#b-platform-apis) capabilities by providing historic social care data from Mosaic to the Social Care System. |

--- a/docs/related-repositories.md
+++ b/docs/related-repositories.md
@@ -7,11 +7,11 @@ title: Related repositories
 
 | Name | Purpose |
 |-|-|
-| [MASH Social Care Referral Form Ingestion Script](https://github.com/LBHackney-IT/social-care-referral-form-ingestion) | Apps Script code that retrieves MASH form data submitted to Google Sheets, processes it and sends the data into Social Care System |
 | [LBH Social Care Frontend](https://github.com/LBHackney-IT/lbh-social-care-frontend) | Provides the UI/UX of the Social Care System. |
 | [Social Care Case Viewer API](https://github.com/LBHackney-IT/social-care-case-viewer-api) | Provides [service API](http://playbook.hackney.gov.uk/API-Playbook/platform_api_vs_service_api#a-service-apis) capabilities to the Social Care System. |
 | [Residents Social Care Platform API](https://github.com/LBHackney-IT/residents-social-care-platform-api) | Provides [platform API](http://playbook.hackney.gov.uk/API-Playbook/platform_api_vs_service_api#b-platform-apis) capabilities by providing historic social care data from Mosaic to the Social Care System. |
 | [Adult Social Care Care Package Builder Frontend](https://github.com/LBHackney-IT/lbh-adult-social-care-frontend) | Provides the UI/UX of the Adult Social Care Package System. |
 | [Adult Social Care Care Package Builder API](https://github.com/LBHackney-IT/lbh-adult-social-care-api) | Provides [service API](http://playbook.hackney.gov.uk/API-Playbook/platform_api_vs_service_api#a-service-apis) capabilities to the Adult Social Care Package System, allowing users to build and manage care packages. |
 | [Adult Social Care Package Builder Transactions API](https://github.com/LBHackney-IT/lbh-adult-social-care-transactions-api) | Provides [service API](http://playbook.hackney.gov.uk/API-Playbook/platform_api_vs_service_api#a-service-apis) transaction capabilities to the Adult Social Care Package System, managing package transactions, pay runs, invoices, bills etc. |
+| [MASH Social Care Referral Form Ingestion Script](https://github.com/LBHackney-IT/social-care-referral-form-ingestion) | Apps Script code that retrieves MASH form data submitted to Google Sheets, processes it and sends the data into Social Care System |
 | [Infrastructure](https://github.com/LBHackney-IT/infrastructure) | Provides a single place for AWS infrastructure defined using [Terraform](https://www.terraform.io) as [infrastructure as code](https://en.wikipedia.org/wiki/Infrastructure_as_code) as part of Hackney's new AWS account strategy. NB: Due to its recent introduction, the Social Care System has infrastructure across multiple places. |


### PR DESCRIPTION
We've started work on integrating MASH work into the social care system. This updates the documentation to include the referrals repo in the list of related repos within the Social Care architecture.